### PR TITLE
Add support for batching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
+name = "async-compression"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +652,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1764,6 +1796,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -1792,6 +1825,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ protobuf = "3.3.0"
 prost = "0.12.3"
 rocket = { version = "0.5.0", features = ["json"] }
 tokio = { version = "1.35.1", features = ["full"] }
-reqwest = "0.12.0"
+reqwest = { version = "0.12.0", features = ["gzip"] }
 futures = "0.3.30"
 envy = "0.4.2"
 serde = { version = "1.0.130" }

--- a/src/datastore/data_providers/http_data_provider.rs
+++ b/src/datastore/data_providers/http_data_provider.rs
@@ -18,6 +18,7 @@ impl HttpDataProvider {
     pub fn new(url: &str) -> Self {
         HttpDataProvider {
             http_client: Client::builder()
+                .gzip(true)
                 .pool_idle_timeout(None)
                 .build()
                 .expect("We must have an http client"),

--- a/src/loggers/debug_logger.rs
+++ b/src/loggers/debug_logger.rs
@@ -19,13 +19,14 @@ impl DebugLogger {
 impl ProxyEventObserverTrait for DebugLogger {
     async fn handle_event(&self, event: &ProxyEvent) {
         println!(
-            "[Debug][Event: {:?}] sdk_key: {}, lcut: {}",
+            "[Debug][Event: {:?}] sdk_key: {}, lcut: {}, stat: {:?}",
             event.event_type,
             event.sdk_key,
             match event.lcut {
                 Some(lcut) => lcut.to_string(),
                 None => "None".to_string(),
-            }
+            },
+            event.stat
         );
     }
 }

--- a/src/observers/mod.rs
+++ b/src/observers/mod.rs
@@ -21,7 +21,7 @@ pub trait NewDcsObserverTrait {
     async fn get(&self, key: &str) -> Option<Arc<String>>;
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ProxyEventType {
     HttpServerRequestSuccess,
     HttpServerRequestFailed,
@@ -53,6 +53,7 @@ pub enum OperationType {
     IncrByValue,
 }
 
+#[derive(Debug)]
 pub struct EventStat {
     pub operation_type: OperationType,
     pub value: i64,

--- a/src/server.rs
+++ b/src/server.rs
@@ -32,6 +32,10 @@ struct Cli {
     debug_logging: bool,
     #[clap(short, long, default_value = "1000")]
     maximum_concurrent_sdk_keys: u16,
+    #[clap(short, long, default_value = "10")]
+    polling_interval_in_s: u64,
+    #[clap(short, long, default_value = "64")]
+    update_batch_size: u64,
 }
 
 #[derive(Deserialize, Debug)]
@@ -82,6 +86,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         shared_cache.clone(),
         shared_http_data_provider,
         shared_dcs_observer.clone(),
+        cli.polling_interval_in_s,
+        cli.update_batch_size,
     );
     let shared_background_data_provider = Arc::new(background_data_provider);
     let sdk_key_store = Arc::new(sdk_key_store::SdkKeyStore::new());


### PR DESCRIPTION
# Summary

When testing with hundreds of SDK keys to update at once, we can see the http client get overwhelemed from the concurrency. As a result, add support for a batch size parameter.