### PR TITLE
Performance optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +601,20 @@ name = "dary_heap"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "debugid"
@@ -1803,9 +1823,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2875,6 +2895,7 @@ dependencies = [
  "chrono",
  "clap",
  "cloud_profiler_rust",
+ "dashmap",
  "dogstatsd",
  "envy",
  "futures",
@@ -2882,6 +2903,7 @@ dependencies = [
  "libflate",
  "lru",
  "once_cell",
+ "parking_lot",
  "prost",
  "protobuf 3.4.0",
  "redis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ serde_with = "3.9.0"
 libflate = "2.1.0"
 serde_json = "1.0.120"
 once_cell = "1.19.0"
+parking_lot = "0.12.3"
+dashmap = "6.1.0"
 
 
 [build-dependencies]

--- a/src/datastore/caching/redis_cache.rs
+++ b/src/datastore/caching/redis_cache.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, sync::Arc};
 
 use bb8_redis::{redis::AsyncCommands, RedisConnectionManager};
+use parking_lot::RwLock;
 use redis::aio::MultiplexedConnection;
-use tokio::sync::RwLock;
 
 use crate::{
     datastore::data_providers::DataProviderRequestResult,
@@ -91,11 +91,10 @@ impl RedisCache {
     }
 
     async fn hash_key(&self, key: &str) -> String {
-        if self.hash_cache.read().await.contains_key(key) {
+        if self.hash_cache.read().contains_key(key) {
             return self
                 .hash_cache
                 .read()
-                .await
                 .get(key)
                 .expect("Must have key")
                 .to_string();
@@ -106,7 +105,6 @@ impl RedisCache {
         let hashed_key = format!("{}::{:x}", self.key_prefix, Sha256::digest(key));
         self.hash_cache
             .write()
-            .await
             .insert(key.to_string(), hashed_key.clone());
         hashed_key
     }

--- a/src/observers/proxy_event_observer.rs
+++ b/src/observers/proxy_event_observer.rs
@@ -30,15 +30,15 @@ impl ProxyEventObserver {
     }
 
     pub async fn publish_event(mut event: ProxyEvent) {
-        if let Some(sdk_key) = event.sdk_key {
-            event.sdk_key = Some(format!(
-                "{}{}",
-                sdk_key.chars().take(20).collect::<String>(),
-                "***"
-            ));
-        }
-
         task::spawn(async move {
+            if let Some(sdk_key) = event.sdk_key {
+                event.sdk_key = Some(format!(
+                    "{}{}",
+                    sdk_key.chars().take(20).collect::<String>(),
+                    "***"
+                ));
+            }
+
             for observer in PROXY_EVENT_OBSERVER.observers.read().await.iter() {
                 observer.handle_event(&event).await;
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -172,10 +172,8 @@ async fn create_config_spec_store(
     CachedRequestBuilders::add_request_builder(
         "/v1/download_config_specs/",
         dcs_request_builder.clone(),
-    )
-    .await;
-    CachedRequestBuilders::add_request_builder("/v2/download_config_specs/", dcs_request_builder)
-        .await;
+    );
+    CachedRequestBuilders::add_request_builder("/v2/download_config_specs/", dcs_request_builder);
     let config_spec_store = Arc::new(datastore::config_spec_store::ConfigSpecStore::new(
         sdk_key_store.clone(),
         background_data_provider.clone(),
@@ -221,7 +219,7 @@ async fn create_id_list_store(
         Arc::clone(&idlist_observer),
         Arc::clone(&shared_cache),
     ));
-    CachedRequestBuilders::add_request_builder("/v1/get_id_lists/", idlist_request_builder).await;
+    CachedRequestBuilders::add_request_builder("/v1/get_id_lists/", idlist_request_builder);
     let id_list_store = Arc::new(datastore::get_id_list_store::GetIdListStore::new(
         sdk_key_store.clone(),
         background_data_provider.clone(),

--- a/src/servers/grpc_server.rs
+++ b/src/servers/grpc_server.rs
@@ -87,8 +87,8 @@ impl StatsigForwardProxy for StatsigForwardProxyServerImpl {
             }
         };
         let reply = ConfigSpecResponse {
-            spec: data.read().await.config.to_string(),
-            last_updated: data.read().await.lcut,
+            spec: data.read().config.to_string(),
+            last_updated: data.read().lcut,
         };
         Ok(Response::new(reply))
     }

--- a/src/servers/http_server.rs
+++ b/src/servers/http_server.rs
@@ -115,7 +115,7 @@ async fn get_download_config_specs(
         .get_config_spec(&authorized_rc, sinceTime.unwrap_or(0))
         .await
     {
-        Some(data) => Ok(data.read().await.config.to_string()),
+        Some(data) => Ok(data.read().config.to_string()),
         None => Err(Status::Unauthorized),
     }
 }
@@ -137,7 +137,7 @@ async fn post_download_config_specs(
         .get_config_spec(&authorized_rc, dcs_request.since_time.unwrap_or(0))
         .await
     {
-        Some(data) => Ok(data.read().await.config.to_string()),
+        Some(data) => Ok(data.read().config.to_string()),
         None => Err(Status::Unauthorized),
     }
 }
@@ -148,7 +148,7 @@ async fn post_get_id_lists(
     authorized_rc: AuthorizedRequestContext,
 ) -> Result<String, Status> {
     match get_id_list_store.get_id_lists(&authorized_rc).await {
-        Some(data) => Ok(data.read().await.idlists.to_string()),
+        Some(data) => Ok(data.read().idlists.to_string()),
         None => Err(Status::Unauthorized),
     }
 }


### PR DESCRIPTION
# Summary

We were seeing a number of performance regressions at high qps due to lock contention, so we worked on addressing these things with the following:
- In non-async scenarios, use parking_lot RwLocks which are more performant for these basic situations
- In our core data stores, leverage a dashmap which has internal sharding to reduce lock contention on shared hashmaps which only use a lock for shared storage
- Improve logic for reading and writing to reduce lock contention and lock holding as much as possible by moving almost all logic out of the critical section
- In scenarios where there is an outer an inner lock, only ever hold the write lock on the outer lock if there is no valid entry that exists yet, else only use a read lock
- Fixed a race condition which could cause more outbound requests on a cache miss than needed (should be bounded at 1, but at high qps, can go to 10s/100s)
- Used fixed sized vectors to reduce memory utilization
- Moved sdk_key parsing off of main request thread and into event handler thread