### PR TITLE
Updates for version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,26 +21,51 @@ Usage: server [OPTIONS] <MODE> <CACHE>
 
 Arguments:
   <MODE>   [possible values: grpc-and-http, grpc, http]
-  <CACHE>  [possible values: disabled, local, redis]
+  <CACHE>  [possible values: disabled, redis]
 
 Options:
+      --double-write-cache-for-legacy-key
+
       --datadog-logging
+
       --statsd-logging
+
       --statsig-logging
+
       --debug-logging
-  -m, --maximum-concurrent-sdk-keys <MAXIMUM_CONCURRENT_SDK_KEYS>  [default: 1000]
-  -p, --polling-interval-in-s <POLLING_INTERVAL_IN_S>              [default: 10]
-  -u, --update-batch-size <UPDATE_BATCH_SIZE>                      [default: 64]
-  -r, --redis-leader-key-ttl <REDIS_LEADER_KEY_TTL>                [default: 70]
-      --redis-cache-ttl-in-s <REDIS_CACHE_TTL_IN_S>                [default: 86400]
+
+  -m, --maximum-concurrent-sdk-keys <MAXIMUM_CONCURRENT_SDK_KEYS>
+          [default: 1000]
+  -p, --polling-interval-in-s <POLLING_INTERVAL_IN_S>
+          [default: 10]
+  -u, --update-batch-size <UPDATE_BATCH_SIZE>
+          [default: 64]
+  -r, --redis-leader-key-ttl <REDIS_LEADER_KEY_TTL>
+          [default: 70]
+      --redis-cache-ttl-in-s <REDIS_CACHE_TTL_IN_S>
+          [default: 86400]
+      --log-event-process-queue-size <LOG_EVENT_PROCESS_QUEUE_SIZE>
+          [default: 20000]
       --force-gcp-profiling-enabled
-  -g, --grpc-max-concurrent-streams <GRPC_MAX_CONCURRENT_STREAMS>  [default: 500]
-      --clear-external-datastore-on-unauthorized
+
+  -g, --grpc-max-concurrent-streams <GRPC_MAX_CONCURRENT_STREAMS>
+          [default: 500]
+      --clear-datastore-on-unauthorized
+
       --x509-server-cert-path <X509_SERVER_CERT_PATH>
+
       --x509-server-key-path <X509_SERVER_KEY_PATH>
+
       --x509-client-cert-path <X509_CLIENT_CERT_PATH>
-  -h, --help                                                       Print help
+
+      --enforce-tls <ENFORCE_TLS>
+          [default: true] [possible values: true, false]
+      --enforce-mtls
+
+  -h, --help
+          Print help
   -V, --version
+          Print version
 ```
 1. MODE:  This can be configured as grpc or http or grpc-and-http to allow for easy migrations.
 2. CACHE: This is for the backup cache. Local uses in process memory to cache backup values, while redis,
@@ -53,11 +78,12 @@ Additional logging parameters we support:
 ```
 --debug-logging: This enables state tracking logging that is emitted for various events within the proxy.
                  It will also emit useful data such as latency for some events.
+--double-write-cache-for-legacy-key: Starting in version 2.x.x, we begin to use a new key schema in preparation for SDKs to manage all key creation in external caches. This allows you to gracefully migrate by double writing to the old key as well.
 --statsig-logging: Send events to Statsig to monitor performance and behaviour of proxy.
 --statsd-logging: This will emit the same metrics and events using statsd.
 --datadog-logging: Same as statsd logging, but uses distribution metrics instead of timing
 --force_gcp_profiling_enabled: Enable gcp cloud profiler by force.
---clear-external-datastore-on-unauthorized: When a 401/403 is received, clear external caches (such as redis). Noting that this is a potential reliability trade off.
+--clear-datastore-on-unauthorized: When a 401/403 is received, clear external caches (such as redis), as well as, internal caches. Noting that this is a potential reliability trade off.
 ```
 
 # Configuration

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,5 +1,6 @@
 [global]
-address = "0.0.0.0"
+address = "127.0.0.1"
+port = 8001
 limits = { json = "5 MiB", string = "5 MiB" }
 log_level = "critical"
 workers = 128

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Start Nginx in the background, redirecting output to /dev/null
+nginx -g 'daemon off; error_log /dev/stderr error;' > /dev/null 2>&1 &
+
+# Execute the main application
+exec statsig_forward_proxy "$@"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,47 @@
+worker_processes auto;
+worker_cpu_affinity auto;
+
+events {
+    worker_connections 1024;
+    multi_accept on;
+    use epoll;
+}
+
+http {
+    proxy_cache_path /dev/shm/nginx levels=1:2 keys_zone=download_cache:10m max_size=1024m inactive=1m use_temp_path=off;
+
+    server {
+        listen 8000;
+        server_name localhost;
+
+        # Disable caching for /v1/log_event
+        location /v1/log_event {
+            proxy_pass http://127.0.0.1:8001;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Disable caching for this location
+            proxy_cache off;
+        }
+
+        # Cache everything else
+        location / {
+            proxy_pass http://127.0.0.1:8001;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Enable caching
+            proxy_cache download_cache;
+            proxy_cache_methods GET POST;
+            proxy_cache_key "$request_method$request_uri$http_statsig_api_key$http_accept_encoding$request_body";
+            proxy_cache_use_stale updating error timeout http_500 http_502 http_503 http_504;
+            proxy_cache_background_update on;
+            proxy_cache_valid 200 5s;
+            proxy_cache_lock on;
+        }
+    }
+}

--- a/src/datastore/caching/mod.rs
+++ b/src/datastore/caching/mod.rs
@@ -1,3 +1,2 @@
 pub mod disabled_cache;
-pub mod in_memory_cache;
 pub mod redis_cache;

--- a/src/datastore/config_spec_store.rs
+++ b/src/datastore/config_spec_store.rs
@@ -129,7 +129,16 @@ impl ConfigSpecStore {
         if !self.sdk_key_store.has_key(request_context) {
             // Since it's a cache-miss, just fill with a full payload
             // and check if we should return no update manually
-            foreground_fetch(self.background_data_provider.clone(), request_context, 0).await;
+            foreground_fetch(
+                self.background_data_provider.clone(),
+                request_context,
+                0,
+                // Since it's a cache-miss, it doesn't matter what we do
+                // if we receive a 4xx, so no point clearing any
+                // caches
+                false,
+            )
+            .await;
         }
 
         // TODO: Since we use peek as an optimization

--- a/src/datastore/mod.rs
+++ b/src/datastore/mod.rs
@@ -1,6 +1,5 @@
 pub mod caching;
 pub mod config_spec_store;
 pub mod data_providers;
-pub mod get_id_list_store;
 pub mod log_event_store;
 pub mod sdk_key_store;

--- a/src/datastore/sdk_key_store.rs
+++ b/src/datastore/sdk_key_store.rs
@@ -70,7 +70,7 @@ impl SdkKeyStore {
         self.keystore.read().contains_key(request_context)
     }
 
-    pub async fn get_registered_store(&self) -> Vec<(Arc<AuthorizedRequestContext>, u64)> {
+    pub fn get_registered_store(&self) -> Vec<(Arc<AuthorizedRequestContext>, u64)> {
         self.keystore
             .read()
             .iter()

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,11 +7,9 @@ use datastore::caching::disabled_cache;
 use datastore::config_spec_store::ConfigSpecStore;
 use datastore::data_providers::request_builder::CachedRequestBuilders;
 use datastore::data_providers::request_builder::DcsRequestBuilder;
-use datastore::data_providers::request_builder::IdlistRequestBuilder;
-use datastore::get_id_list_store::GetIdListStore;
 use datastore::log_event_store::LogEventStore;
 use datastore::{
-    caching::{in_memory_cache, redis_cache},
+    caching::redis_cache,
     data_providers::{background_data_provider, http_data_provider},
     sdk_key_store,
 };
@@ -52,6 +50,8 @@ pub struct Cli {
     mode: TransportMode,
     #[arg(value_enum)]
     cache: CacheMode,
+    #[clap(long, action)]
+    double_write_cache_for_legacy_key: bool,
     // Deprecated: Same as statsd logging
     #[clap(long, action)]
     datadog_logging: bool,
@@ -77,12 +77,14 @@ pub struct Cli {
     force_gcp_profiling_enabled: bool,
     #[clap(short, long, default_value = "500")]
     grpc_max_concurrent_streams: u32,
-    // If you set this flag, you do not need an external process
-    // to clean up the external datastore if your key becomes unauthorized.
-    // The downside is that if there are issues with auth upstream, you might create
-    // inavailability of the config.
+    // By default, we do not enable this configuration. This allows you to ensure
+    // if there are any issues with authorization on Statsig's end you still
+    // have a payload to server.
+    //
+    // This means if you delete a key, until the service is restarted, the entry
+    // from internal or external caches
     #[clap(long, action)]
-    clear_external_datastore_on_unauthorized: bool,
+    clear_datastore_on_unauthorized: bool,
 
     // Authorization and TLS Configuration:
     #[clap(long, default_value = None)]
@@ -115,7 +117,6 @@ enum TransportMode {
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum CacheMode {
     Disabled,
-    Local,
     Redis,
 }
 
@@ -127,8 +128,8 @@ async fn try_initialize_statsig_sdk_and_profiling(cli: &Cli, config: &Configurat
                 // to decide whether or not to enable GCP Profiling
                 api_for_download_config_specs: match cli.mode {
                     TransportMode::Grpc => "https://api.statsigcdn.com/v1".to_string(),
-                    TransportMode::Http => "http://0.0.0.0:8000/v1".to_string(),
-                    TransportMode::GrpcAndHttp => "http://0.0.0.0:8000/v1".to_string(),
+                    TransportMode::Http => "http://127.0.0.1:8001/v1".to_string(),
+                    TransportMode::GrpcAndHttp => "http://127.0.0.1:8001/v1".to_string(),
                 },
                 disable_user_agent_support: true,
                 ..StatsigOptions::default()
@@ -219,29 +220,6 @@ async fn create_config_spec_store(
     config_spec_store
 }
 
-async fn create_id_list_store(
-    _overrides: &ConfigurationAndOverrides,
-    background_data_provider: Arc<background_data_provider::BackgroundDataProvider>,
-    idlist_observer: Arc<HttpDataProviderObserver>,
-    shared_cache: &Arc<dyn HttpDataProviderObserverTrait + Send + Sync>,
-    sdk_key_store: &Arc<sdk_key_store::SdkKeyStore>,
-) -> Arc<GetIdListStore> {
-    let idlist_request_builder = Arc::new(IdlistRequestBuilder::new(
-        Arc::clone(&idlist_observer),
-        Arc::clone(shared_cache),
-    ));
-    CachedRequestBuilders::add_request_builder("/v1/get_id_lists/", idlist_request_builder);
-    let id_list_store = Arc::new(datastore::get_id_list_store::GetIdListStore::new(
-        sdk_key_store.clone(),
-        background_data_provider.clone(),
-    ));
-    idlist_observer.add_observer(sdk_key_store.clone()).await;
-    idlist_observer.add_observer(id_list_store.clone()).await;
-    idlist_observer.add_observer(Arc::clone(shared_cache)).await;
-
-    id_list_store
-}
-
 async fn create_log_event_store(
     http_client: reqwest::Client,
     config: &ConfigurationAndOverrides,
@@ -286,43 +264,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cli.polling_interval_in_s,
         cli.update_batch_size,
         Arc::clone(&sdk_key_store),
+        cli.clear_datastore_on_unauthorized,
     ));
     let cache_uuid = Uuid::new_v4().to_string();
     let config_spec_cache: Arc<dyn HttpDataProviderObserverTrait + Send + Sync> = match cli.cache {
-        CacheMode::Local => Arc::new(in_memory_cache::InMemoryCache::new(
-            cli.maximum_concurrent_sdk_keys,
-        )),
         CacheMode::Redis => Arc::new(
             redis_cache::RedisCache::new(
                 "statsig".to_string(),
                 cli.redis_leader_key_ttl,
                 &cache_uuid,
                 true, /* check lcut */
-                cli.clear_external_datastore_on_unauthorized,
                 cli.redis_cache_ttl_in_s,
+                cli.double_write_cache_for_legacy_key,
             )
             .await,
         ),
         CacheMode::Disabled => Arc::new(disabled_cache::DisabledCache::default()),
     };
-    let id_list_cache: Arc<dyn HttpDataProviderObserverTrait + Send + Sync> = match cli.cache {
-        CacheMode::Local => Arc::new(in_memory_cache::InMemoryCache::new(
-            cli.maximum_concurrent_sdk_keys,
-        )),
-        CacheMode::Redis => Arc::new(
-            redis_cache::RedisCache::new(
-                "statsig_id_list".to_string(),
-                cli.redis_leader_key_ttl,
-                &cache_uuid,
-                false, /* check lcut */
-                cli.clear_external_datastore_on_unauthorized,
-                cli.redis_cache_ttl_in_s,
-            )
-            .await,
-        ),
-        CacheMode::Disabled => Arc::new(disabled_cache::DisabledCache::default()),
-    };
-
     let config_spec_observer = Arc::new(HttpDataProviderObserver::new());
     let config_spec_store = create_config_spec_store(
         &cli,
@@ -330,15 +288,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Arc::clone(&background_data_provider),
         Arc::clone(&config_spec_observer),
         &config_spec_cache,
-        &sdk_key_store,
-    )
-    .await;
-    let idlist_observer = Arc::new(HttpDataProviderObserver::new());
-    let id_list_store = create_id_list_store(
-        &overrides,
-        Arc::clone(&background_data_provider),
-        Arc::clone(&idlist_observer),
-        &id_list_cache,
         &sdk_key_store,
     )
     .await;
@@ -366,7 +315,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             servers::http_server::HttpServer::start_server(
                 &cli,
                 config_spec_store,
-                id_list_store,
                 log_event_store,
                 rc_cache,
             )
@@ -382,7 +330,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let http_server = servers::http_server::HttpServer::start_server(
                 &cli,
                 config_spec_store,
-                id_list_store,
                 log_event_store,
                 rc_cache,
             );


### PR DESCRIPTION
# Summary (All breaking changes)
- Change clear_external_datastore_on_unauthorized to clear_datastore_on_unauthorized to prevent clearing internal caches as well incase we have a SEV where authorization is broken. The assumption for now is that deleting SDK keys is relatively rare. Restart of service will clear the internal cache.
- Deprecated idlist from SFP because we are moving to a more sustainable solution for serving IDlist payloads
- Introduce a new schema for external cache keys such that we can begin to strictly formalize the definition in our SDKs
- Remove in memory backup cache, it was introduced for testing, but customers continue to use it by accident
- Embed Nginx to front the service to allow for higher QPS volumes than what is natively supported by rocket