### PR TITLE
Redis cache bug fix and put back get_id_lists

### DIFF
--- a/src/datastore/caching/disabled_cache.rs
+++ b/src/datastore/caching/disabled_cache.rs
@@ -1,5 +1,8 @@
 use crate::{
-    datastore::data_providers::{http_data_provider::ResponsePayload, DataProviderRequestResult},
+    datastore::{
+        config_spec_store::ConfigSpecForCompany,
+        data_providers::{http_data_provider::ResponsePayload, DataProviderRequestResult},
+    },
     observers::HttpDataProviderObserverTrait,
     servers::authorized_request_context::AuthorizedRequestContext,
 };
@@ -29,7 +32,7 @@ impl HttpDataProviderObserverTrait for DisabledCache {
     async fn get(
         &self,
         _request_context: &Arc<AuthorizedRequestContext>,
-    ) -> Option<Arc<ResponsePayload>> {
+    ) -> Option<Arc<ConfigSpecForCompany>> {
         return None;
     }
 }

--- a/src/datastore/data_providers/background_data_provider.rs
+++ b/src/datastore/data_providers/background_data_provider.rs
@@ -223,8 +223,8 @@ impl BackgroundDataProvider {
                         &request_builder,
                         &dp_result.result,
                         request_context,
-                        lcut,
-                        &backup_data,
+                        backup_data.lcut,
+                        &backup_data.config,
                     )
                     .await;
                 }

--- a/src/datastore/data_providers/http_data_provider.rs
+++ b/src/datastore/data_providers/http_data_provider.rs
@@ -154,6 +154,10 @@ impl HttpDataProvider {
         start_time: Instant,
         request_context: &Arc<AuthorizedRequestContext>,
     ) -> u64 {
+        if !request_context.use_lcut {
+            return lcut;
+        }
+
         headers
             .get("x-since-time")
             .and_then(|value| value.to_str().ok())

--- a/src/datastore/data_providers/request_builder.rs
+++ b/src/datastore/data_providers/request_builder.rs
@@ -1,8 +1,9 @@
 use async_trait::async_trait;
 
 use parking_lot::RwLock;
+use sha2::{Digest, Sha256};
 use std::{collections::HashMap, sync::Arc};
-use tokio::time::Duration;
+use tokio::time::{Duration, Instant};
 
 use crate::{
     observers::{
@@ -148,5 +149,100 @@ impl RequestBuilderTrait for DcsRequestBuilder {
 
     async fn should_make_request(&self, _rc: &Arc<AuthorizedRequestContext>) -> bool {
         true
+    }
+}
+
+pub struct IdlistRequestBuilder {
+    pub http_observers: Arc<HttpDataProviderObserver>,
+    pub backup_cache: Arc<dyn HttpDataProviderObserverTrait + Sync + Send>,
+    last_request_by_key: RwLock<HashMap<String, Instant>>,
+    last_response_hash: RwLock<HashMap<String, String>>,
+}
+
+impl IdlistRequestBuilder {
+    pub fn new(
+        http_observers: Arc<HttpDataProviderObserver>,
+        backup_cache: Arc<dyn HttpDataProviderObserverTrait + Sync + Send>,
+    ) -> IdlistRequestBuilder {
+        IdlistRequestBuilder {
+            http_observers,
+            backup_cache,
+            last_request_by_key: RwLock::new(HashMap::new()),
+            last_response_hash: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl RequestBuilderTrait for IdlistRequestBuilder {
+    async fn make_request(
+        &self,
+        http_client: &reqwest::Client,
+        request_context: &Arc<AuthorizedRequestContext>,
+        _lcut: u64,
+    ) -> Result<reqwest::Response, reqwest::Error> {
+        match http_client
+            .post("https://api.statsig.com/v1/get_id_lists".to_string())
+            .header("statsig-api-key", request_context.sdk_key.clone())
+            .body("{}".to_string())
+            .send()
+            .await
+        {
+            Ok(response) => {
+                let status_code = response.status().as_u16();
+                // If unauthorized, remove key from last response hash such that
+                // we will reload data into memory if for some reason the key is
+                // re-authorized
+                if status_code == 401 || status_code == 403 {
+                    self.last_response_hash
+                        .write()
+                        .remove(&request_context.sdk_key);
+                }
+                Ok(response)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn is_an_update(&self, body: &str, sdk_key: &str) -> bool {
+        let hash = format!("{:x}", Sha256::digest(body));
+        let mut wlock = self.last_response_hash.write();
+        let mut is_an_update = true;
+        if let Some(old_hash) = wlock.get(sdk_key) {
+            is_an_update = hash != *old_hash;
+        }
+
+        if is_an_update {
+            wlock.insert(sdk_key.to_string(), hash);
+        }
+
+        is_an_update
+    }
+
+    fn get_observers(&self) -> Arc<HttpDataProviderObserver> {
+        Arc::clone(&self.http_observers)
+    }
+
+    fn get_backup_cache(&self) -> Arc<dyn HttpDataProviderObserverTrait + Sync + Send> {
+        Arc::clone(&self.backup_cache)
+    }
+
+    async fn should_make_request(&self, rc: &Arc<AuthorizedRequestContext>) -> bool {
+        let mut wlock = self.last_request_by_key.write();
+        let key = rc.to_string();
+        match wlock.get_mut(&key) {
+            Some(last_request) => {
+                if last_request.elapsed() > Duration::from_secs(60) {
+                    wlock.insert(key, Instant::now());
+                    return true;
+                }
+
+                return false;
+            }
+            None => {
+                wlock.insert(key, Instant::now());
+                return true;
+            }
+        }
     }
 }

--- a/src/datastore/id_list_store.rs
+++ b/src/datastore/id_list_store.rs
@@ -1,0 +1,89 @@
+use super::config_spec_store::ConfigSpecForCompany;
+use super::data_providers::background_data_provider::{foreground_fetch, BackgroundDataProvider};
+use super::data_providers::http_data_provider::ResponsePayload;
+use super::data_providers::DataProviderRequestResult;
+use super::sdk_key_store::SdkKeyStore;
+use crate::observers::HttpDataProviderObserverTrait;
+use crate::servers::authorized_request_context::AuthorizedRequestContext;
+use dashmap::DashMap;
+
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct IdlistForCompany {
+    pub idlists: Arc<ResponsePayload>,
+}
+
+pub struct GetIdListStore {
+    store: Arc<DashMap<Arc<AuthorizedRequestContext>, Arc<IdlistForCompany>>>,
+    sdk_key_store: Arc<SdkKeyStore>,
+    background_data_provider: Arc<BackgroundDataProvider>,
+}
+
+use async_trait::async_trait;
+#[async_trait]
+impl HttpDataProviderObserverTrait for GetIdListStore {
+    fn force_notifier_to_wait_for_update(&self) -> bool {
+        true
+    }
+
+    async fn update(
+        &self,
+        result: &DataProviderRequestResult,
+        request_context: &Arc<AuthorizedRequestContext>,
+        _lcut: u64,
+        data: &Arc<ResponsePayload>,
+    ) {
+        if result == &DataProviderRequestResult::Error
+            || result == &DataProviderRequestResult::DataAvailable
+        {
+            self.store.insert(
+                Arc::clone(request_context),
+                Arc::new(IdlistForCompany {
+                    idlists: data.clone(),
+                }),
+            );
+        } else if result == &DataProviderRequestResult::Unauthorized {
+            self.store.remove(request_context);
+        }
+    }
+
+    async fn get(
+        &self,
+        _request_context: &Arc<AuthorizedRequestContext>,
+    ) -> Option<Arc<ConfigSpecForCompany>> {
+        unimplemented!()
+    }
+}
+
+impl GetIdListStore {
+    pub fn new(
+        sdk_key_store: Arc<SdkKeyStore>,
+        background_data_provider: Arc<BackgroundDataProvider>,
+    ) -> Self {
+        GetIdListStore {
+            store: Arc::new(DashMap::new()),
+            sdk_key_store,
+            background_data_provider,
+        }
+    }
+
+    pub async fn get_id_lists(
+        &self,
+        request_context: &Arc<AuthorizedRequestContext>,
+    ) -> Option<Arc<IdlistForCompany>> {
+        if !self.sdk_key_store.has_key(request_context) {
+            // Since it's a cache-miss, just fill with a full payload
+            // and check if we should return no update manually
+            foreground_fetch(
+                self.background_data_provider.clone(),
+                request_context,
+                0,
+                false,
+            )
+            .await;
+        }
+
+        self.store.get(request_context).map(|r| r.clone())
+    }
+}

--- a/src/datastore/mod.rs
+++ b/src/datastore/mod.rs
@@ -1,5 +1,6 @@
 pub mod caching;
 pub mod config_spec_store;
 pub mod data_providers;
+pub mod id_list_store;
 pub mod log_event_store;
 pub mod sdk_key_store;

--- a/src/datastore/sdk_key_store.rs
+++ b/src/datastore/sdk_key_store.rs
@@ -1,3 +1,4 @@
+use super::config_spec_store::ConfigSpecForCompany;
 use super::data_providers::http_data_provider::ResponsePayload;
 use super::data_providers::DataProviderRequestResult;
 use crate::observers::HttpDataProviderObserverTrait;
@@ -44,7 +45,7 @@ impl HttpDataProviderObserverTrait for SdkKeyStore {
     async fn get(
         &self,
         _request_context: &Arc<AuthorizedRequestContext>,
-    ) -> Option<Arc<ResponsePayload>> {
+    ) -> Option<Arc<ConfigSpecForCompany>> {
         None
     }
 }

--- a/src/observers/mod.rs
+++ b/src/observers/mod.rs
@@ -8,7 +8,10 @@ use async_trait::async_trait;
 use once_cell::sync::Lazy;
 
 use crate::{
-    datastore::data_providers::{http_data_provider::ResponsePayload, DataProviderRequestResult},
+    datastore::{
+        config_spec_store::ConfigSpecForCompany,
+        data_providers::{http_data_provider::ResponsePayload, DataProviderRequestResult},
+    },
     servers::authorized_request_context::AuthorizedRequestContext,
 };
 
@@ -26,7 +29,7 @@ pub trait HttpDataProviderObserverTrait {
     async fn get(
         &self,
         request_context: &Arc<AuthorizedRequestContext>,
-    ) -> Option<Arc<ResponsePayload>>;
+    ) -> Option<Arc<ConfigSpecForCompany>>;
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/src/servers/authorized_request_context.rs
+++ b/src/servers/authorized_request_context.rs
@@ -101,7 +101,7 @@ impl AuthorizedRequestContext {
             normalized_path.push('/');
         }
 
-        let use_lcut = normalized_path.ends_with("download_config_specs");
+        let use_lcut = normalized_path.contains("download_config_specs");
         AuthorizedRequestContext {
             sdk_key,
             path: normalized_path,

--- a/src/servers/streaming_channel.rs
+++ b/src/servers/streaming_channel.rs
@@ -1,3 +1,4 @@
+use crate::datastore::config_spec_store::ConfigSpecForCompany;
 use crate::datastore::data_providers::http_data_provider::ResponsePayload;
 use crate::datastore::data_providers::DataProviderRequestResult;
 use crate::observers::HttpDataProviderObserverTrait;
@@ -78,7 +79,7 @@ impl HttpDataProviderObserverTrait for StreamingChannel {
     async fn get(
         &self,
         _request_context: &Arc<AuthorizedRequestContext>,
-    ) -> Option<Arc<ResponsePayload>> {
+    ) -> Option<Arc<ConfigSpecForCompany>> {
         unimplemented!("Not Used")
     }
 }


### PR DESCRIPTION
# Summary
- fix a bug where we weren't doing lcut checks when reading data back from redis
- re-introduced get_id_lists into sfp to unblock a customer need, however, this time with a deprecation warning.