### PR TITLE
[3.0.0] Repo sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,9 +2890,10 @@ dependencies = [
 
 [[package]]
 name = "statsig-forward-proxy"
-version = "1.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "bb8",
  "bb8-redis",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "statsig-forward-proxy"
-version = "1.1.0"
+version = "3.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+base64 = "0.22"
 clap = { version = "4.5.17", features = ["derive"] }
 tonic = { version = "0.12.3", features = ["tls"] }
 protobuf = "3.5.1"

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -276,7 +276,7 @@ These allow you to ensure:
 - the proxy is getting updates
 - the proxy is receiving timely updates
 
-### What does this mean? [sfp] Dropping event... Buffer limit hit...
+### What does this mean? [SFP] Dropping event... Buffer limit hit...
 
 This log is emitted due to the high volume of events being generated. This is directly proportional to QPS your service is receiving.
 

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -1,0 +1,35 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import random
+
+# Rotating index for status codes
+status_codes = [200, 403, 503, 1200] 
+index = 0
+counter = 1
+
+class RotatingStatusHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        global index
+        global counter
+        # Select the current status code
+        status_code = status_codes[index]
+        index = (index + 1) % len(status_codes)  # Rotate the index
+        
+        # Send response header with the selected status code
+        self.send_response(status_code)
+        self.send_header("Content-type", "text/html")
+        if status_code == 200:
+            self.send_header("x-since-time", str(counter))
+            counter += 1
+        self.end_headers()
+        
+        # Send a response body
+        self.wfile.write(f"Status code: {status_code}".encode("utf-8"))
+
+def run(server_class=HTTPServer, handler_class=RotatingStatusHandler, port=8080):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    print(f"Starting server on port {port}...")
+    httpd.serve_forever()
+
+if __name__ == "__main__":
+    run()

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,6 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .tls_config(tls)?
         .connect()
         .await?;
+    let sdk_key = std::env::var("STATSIG_SERVER_SDK_KEY").unwrap().to_string();
 
     let mut client = StatsigForwardProxyClient::new(channel).max_decoding_message_size(20870203);
 
@@ -38,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for version in 0..3 {
         let request = tonic::Request::new(ConfigSpecRequest {
             since_time: Some(1234),
-            sdk_key: "secret-1234".into(),
+            sdk_key: sdk_key.clone(),
             version: Some(version),
         });
         let response: tonic::Response<statsig_forward_proxy::ConfigSpecResponse> =
@@ -56,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Streaming
     let request = tonic::Request::new(ConfigSpecRequest {
         since_time: Some(1234),
-        sdk_key: "secret-1234".into(),
+        sdk_key: sdk_key.clone(),
         version: Some(2),
     });
     let response = client.stream_config_spec(request).await?;

--- a/src/datastore/data_providers/background_data_provider.rs
+++ b/src/datastore/data_providers/background_data_provider.rs
@@ -1,5 +1,6 @@
 use crate::datastore::sdk_key_store::SdkKeyStore;
 use crate::servers::authorized_request_context::AuthorizedRequestContext;
+use crate::utils::compress_encoder::CompressionEncoder;
 use crate::GRACEFUL_SHUTDOWN_TOKEN;
 
 use super::http_data_provider::ResponsePayload;
@@ -237,7 +238,7 @@ impl BackgroundDataProvider {
                         request_context,
                         lcut,
                         &(Arc::new(ResponsePayload {
-                            encoding: Arc::new(None),
+                            encoding: Arc::new(CompressionEncoder::PlainText),
                             data: Arc::new(Bytes::new()),
                         })),
                     )

--- a/src/datastore/data_providers/mod.rs
+++ b/src/datastore/data_providers/mod.rs
@@ -6,7 +6,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use http_data_provider::ResponsePayload;
 
-use crate::servers::authorized_request_context::AuthorizedRequestContext;
+use crate::{
+    servers::authorized_request_context::AuthorizedRequestContext,
+    // utils::compress_encoder::CompressionEncoder,
+};
 
 use self::request_builder::RequestBuilderTrait;
 #[async_trait]
@@ -31,5 +34,6 @@ pub enum DataProviderRequestResult {
 #[derive(Debug)]
 pub struct DataProviderResult {
     result: DataProviderRequestResult,
+    // encoding: CompressionEncoder,
     data: Option<(Arc<ResponsePayload>, u64)>,
 }

--- a/src/observers/mod.rs
+++ b/src/observers/mod.rs
@@ -54,7 +54,9 @@ pub enum ProxyEventType {
     ConfigSpecStoreGotData,
     GrpcStreamingStreamedInitialized,
     GrpcStreamingStreamedResponse,
+    GrpcStreamingHealthcheckSent,
     GrpcStreamingStreamDisconnected,
+    GrpcEstimatedActiveStreams,
     StreamingChannelGotNewData,
     UpdateConfigSpecStorePropagationDelayMs,
     LogEventStoreDeduped,
@@ -89,6 +91,12 @@ impl std::fmt::Display for ProxyEventType {
             }
             ProxyEventType::GrpcStreamingStreamedResponse => {
                 write!(f, "GrpcStreamingStreamedResponse")
+            }
+            ProxyEventType::GrpcStreamingHealthcheckSent => {
+                write!(f, "GrpcStreamingHealthcheckSent")
+            }
+            ProxyEventType::GrpcEstimatedActiveStreams => {
+                write!(f, "GrpcEstimatedActiveStreams")
             }
             ProxyEventType::GrpcStreamingStreamDisconnected => {
                 write!(f, "GrpcStreamingStreamDisconnected")

--- a/src/observers/proxy_event_observer.rs
+++ b/src/observers/proxy_event_observer.rs
@@ -31,6 +31,10 @@ impl Default for ProxyEventObserver {
 
 impl ProxyEventObserver {
     pub fn new() -> Self {
+        if let Some(size) = CONFIG.event_channel_size {
+            println!("[SFP] EVENT_CHANNEL_SIZE is overriden to {}. This can cause higher memory usage due to pre-allocation of channel memory.", size);
+        }
+
         let (tx, _rx) = broadcast::channel(CONFIG.event_channel_size.unwrap_or(100000));
         ProxyEventObserver {
             sender: Arc::new(tx),
@@ -47,12 +51,12 @@ impl ProxyEventObserver {
                             observer.handle_event(&event).await;
                         },
                         Err(RecvError::Closed) => {
-                            eprintln!("[sfp] event writer dropped... removing reader...");
+                            eprintln!("[SFP] event writer dropped... removing reader...");
                             break;
                         },
                         Err(RecvError::Lagged(frames)) => {
                             eprintln!(
-                                "[sfp] event writer lagging by {} messages. Consider increasing EVENT_CHANNEL_SIZE.",
+                                "[SFP] event writer lagging by {} messages. Consider increasing EVENT_CHANNEL_SIZE.",
                                 frames
                             );
                         },
@@ -64,7 +68,7 @@ impl ProxyEventObserver {
 
     pub fn publish_event(event: ProxyEvent) {
         if let Err(e) = PROXY_EVENT_OBSERVER.sender.send(Arc::new(event)) {
-            eprintln!("[sfp] Dropping event... Buffer limit hit... {}", e);
+            eprintln!("[SFP] Dropping event... Buffer limit hit... {}", e);
         }
     }
 }

--- a/src/utils/compress_encoder.rs
+++ b/src/utils/compress_encoder.rs
@@ -1,0 +1,34 @@
+use std::{fmt, str::FromStr};
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum CompressionEncoder {
+    PlainText,
+    Gzip,
+}
+
+impl fmt::Display for CompressionEncoder {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CompressionEncoder::PlainText => write!(f, "plain_text"),
+            CompressionEncoder::Gzip => write!(f, "gzip"),
+        }
+    }
+}
+
+impl std::hash::Hash for CompressionEncoder {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.to_string().hash(state);
+    }
+}
+
+impl FromStr for CompressionEncoder {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "gzip" => Ok(CompressionEncoder::Gzip),
+            _ => Ok(CompressionEncoder::PlainText),
+        }
+    }
+
+    type Err = ();
+}
+
+impl Eq for CompressionEncoder {}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 // Leaving code because it works well; but less performant
 // We might want to try using it again one day
 // pub mod rate_limiter;
+pub mod compress_encoder;
 pub mod statsig_sdk_wrapper;


### PR DESCRIPTION
# Summary
- include sfp version in requests to CDN/origin
- prepare redis cache to support various encoding types
- add lcut slice to redis based metrics
- fix a bug where reading from redis does not check LCUT
- add a metric for estimated active grpc streams